### PR TITLE
divide by 0 error fix

### DIFF
--- a/app/Interpreting.hs
+++ b/app/Interpreting.hs
@@ -66,6 +66,7 @@ safeAdd x y
 
 safeMul :: Int32 -> Int32 -> Interpreter Int32
 safeMul x y
+  | x == 0 || y == 0 = pure 0
   | res `div` y /= x = ierror "Integer overflow occurred"
   | otherwise = pure res
   where


### PR DESCRIPTION
Fixed **Division by Zero Error** in safeMul Function
Changes:
Handled the case where one of the operand is 0 to prevent division by zero errors during overflow checks.
Before the fix:
Calling safeMul 3 0 resulted in a division by zero error while checking for overflow, which was not the expected.
After the fix:
Calling safeMul 3 0 now correctly returns 0, avoiding the division by zero error.